### PR TITLE
DT-36 Optimize Docker builds and replace shadowJar with startScripts                                                                                                 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,138 @@
+name: CI
+on:
+  push:
+    branches: [ master, dev ]
+  pull_request:
+    branches: [ master, dev ]
+
+jobs:
+  build:
+    name: Build ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - delegate-api
+          - user-service
+          - project-service
+          - config-service
+          - data-sources-service
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Compile code
+        run: ./gradlew :${{ matrix.service }}:assemble
+
+      - name: Check
+        run: ./gradlew :${{ matrix.service }}:check
+
+  docker:
+    name: Docker ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - delegate-api
+          - user-service
+          - project-service
+          - config-service
+          - data-sources-service
+
+    env:
+      REGISTRY: ghcr.io
+      REPOSITORY: ${{ github.repository }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Login to Container Registry (${{ env.REGISTRY }})
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase image name
+        run: |
+          echo "DOCKER_IMAGE=${REGISTRY}/${REPOSITORY,,}/${{ matrix.service }}" >>${GITHUB_ENV}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        id: cache-buildx
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.service }}-${{ hashFiles(
+            format('{0}/Dockerfile', matrix.service),
+            'settings.gradle.kts',
+            'build.gradle.kts',
+            'gradle/libs.versions.toml',
+            format('{0}/build.gradle.kts', matrix.service)
+            ) }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.service }}-
+
+      - name: Cache parameters
+        id: cache-parameters
+        run: |
+          if [ "${{ steps.cache-buildx.outputs.cache-hit }}" = "true" ]; then
+            echo "cache-to=" >> $GITHUB_OUTPUT
+          else
+            echo "cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build docker
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: ${{ steps.cache-parameters.outputs.cache-to }}
+          load: true
+          context: .
+          file: ${{ matrix.service }}/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: |
+            ${{ steps.docker_meta.outputs.labels }}
+            org.opencontainers.image.vendor=RADAR-base
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Inspect docker image
+        run: docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
+
+      - name: Push image
+        if: ${{ github.event_name != 'pull_request' }}
+        run: docker push ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
+
+      - name: Move docker build cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  upload:
+    name: Upload ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - delegate-api
+          - user-service
+          - project-service
+          - config-service
+          - data-sources-service
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build ${{ matrix.service }}
+        run: ./gradlew --no-daemon :${{ matrix.service }}:assemble
+
+      - name: Upload to GitHub
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: '${{ matrix.service }}/build/libs/*;${{ matrix.service }}/build/distributions/*'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Docker ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - delegate-api
+          - user-service
+          - project-service
+          - config-service
+          - data-sources-service
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase image name
+        run: |
+          echo "DOCKER_IMAGE=${REGISTRY}/${REPOSITORY,,}/${{ matrix.service }}" >>${GITHUB_ENV}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push docker
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          file: ${{ matrix.service }}/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: |
+            ${{ steps.docker_meta.outputs.labels }}
+            org.opencontainers.image.vendor=RADAR-base
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Inspect docker image
+        run: |
+          docker pull ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
+          docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}

--- a/.github/workflows/scheduled-snyk-docker.yaml
+++ b/.github/workflows/scheduled-snyk-docker.yaml
@@ -1,0 +1,48 @@
+name: Snyk Docker scheduled test
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - delegate-api
+          - user-service
+          - project-service
+          - config-service
+          - data-sources-service
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Lowercase image name
+        run: |
+          echo "DOCKER_IMAGE=${REGISTRY}/${REPOSITORY,,}/${{ matrix.service }}" >>${GITHUB_ENV}
+
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ env.DOCKER_IMAGE }}:latest
+          args: --file=${{ matrix.service }}/Dockerfile --severity-threshold=high
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: snyk.sarif

--- a/.github/workflows/scheduled-snyk.yaml
+++ b/.github/workflows/scheduled-snyk.yaml
@@ -1,0 +1,30 @@
+name: Snyk scheduled test
+on:
+  schedule:
+    - cron: '0 2 * * 1'
+  push:
+    branches:
+      - master
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    env:
+      REPORT_FILE: test.json
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/gradle-jdk17@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --all-projects --configuration-matching='^runtimeClasspath$' --json-file-output=${{ env.REPORT_FILE }} --severity-threshold=high
+
+      - name: Report new vulnerabilities
+        uses: thehyve/report-vulnerability@master
+        if: success() || failure()
+        with:
+          report-file: ${{ env.REPORT_FILE }}
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -1,0 +1,17 @@
+name: Snyk test
+
+on:
+ - pull_request
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run Snyk to check for JDK vulnerabilities
+        uses: snyk/actions/gradle-jdk17@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --all-projects --configuration-matching="^runtimeClasspath$" --fail-on=upgradable --org=radar-base --severity-threshold=high

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,9 @@ plugins {
     alias(libs.plugins.radar.kotlin) apply false
     alias(libs.plugins.radar.dependency.management)
     alias(libs.plugins.kotlin.serialization) apply false
-    alias(libs.plugins.shadow) apply false
 }
 
-val projectVersion = libs.versions.project.get()
+val projectVersion: String = libs.versions.project.get()
 
 val rootImplDeps = listOf(
     libs.jersey.grizzly,
@@ -33,7 +32,6 @@ allprojects {
 
 subprojects {
     apply(plugin = "org.radarbase.radar-kotlin")
-    apply(plugin = "com.github.johnrengelman.shadow")
     apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
 
     repositories {

--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -1,22 +1,31 @@
-FROM eclipse-temurin:17-jdk-jammy as builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy AS builder
 
 WORKDIR /app
 
-COPY gradle/wrapper/gradle-wrapper.jar gradle/wrapper/
-COPY gradlew .
-RUN chmod +x /app/gradlew
-COPY . .
+COPY gradle/ gradle/
+COPY gradlew build.gradle.kts settings.gradle.kts ./
+COPY core/build.gradle.kts core/
+COPY config-service/build.gradle.kts config-service/
 
-RUN ./gradlew :config-service:shadowJar --no-daemon
+RUN chmod +x gradlew && ./gradlew --no-daemon \
+    :config-service:downloadDependencies \
+    :config-service:copyDependencies \
+    :config-service:startScripts
+
+COPY core/src/ core/src/
+COPY config-service/src/ config-service/src/
+
+RUN ./gradlew --no-daemon :config-service:jar
 
 FROM eclipse-temurin:17-jre-jammy
 
-WORKDIR /app
+COPY --from=builder /app/config-service/build/scripts/* /usr/bin/
+COPY --from=builder /app/config-service/build/third-party/* /usr/lib/
+COPY --from=builder /app/config-service/build/libs/*.jar /usr/lib/
+COPY --from=builder /app/config-service/src/main/resources/config.yaml /etc/config-service/config.yaml
 
-COPY --from=builder /app/config-service/build/libs/*-all.jar /app/app.jar
+USER 101
 
 EXPOSE 8083
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
-
-
+ENTRYPOINT ["config-service"]

--- a/config-service/src/main/kotlin/org/radarbase/config/ConfigServiceApplication.kt
+++ b/config-service/src/main/kotlin/org/radarbase/config/ConfigServiceApplication.kt
@@ -16,7 +16,10 @@ class ConfigServiceApplication {
         @JvmStatic
         fun main(args: Array<String>) {
             val config = try {
-                ConfigLoader.loadConfig<ConfigServiceConfig>("config.yaml", args)
+                ConfigLoader.loadConfig<ConfigServiceConfig>(
+                    listOf("config-service/src/main/resources/config.yaml", "/etc/config-service/config.yaml"),
+                    args,
+                )
             } catch (_: IllegalArgumentException) {
                 logger.error("No configuration file was found.")
                 logger.error("Usage: config-service <config-file>")

--- a/data-sources-service/Dockerfile
+++ b/data-sources-service/Dockerfile
@@ -1,18 +1,31 @@
-ARG VERSION=1.0.0
-FROM eclipse-temurin:17-jdk-jammy as builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy AS builder
 
 WORKDIR /app
-COPY gradle/wrapper/gradle-wrapper.jar gradle/wrapper/
-COPY gradlew .
-RUN chmod +x /app/gradlew
-COPY . .
-RUN ./gradlew :data-sources-service:shadowJar --no-daemon
+
+COPY gradle/ gradle/
+COPY gradlew build.gradle.kts settings.gradle.kts ./
+COPY core/build.gradle.kts core/
+COPY data-sources-service/build.gradle.kts data-sources-service/
+
+RUN chmod +x gradlew && ./gradlew --no-daemon \
+    :data-sources-service:downloadDependencies \
+    :data-sources-service:copyDependencies \
+    :data-sources-service:startScripts
+
+COPY core/src/ core/src/
+COPY data-sources-service/src/ data-sources-service/src/
+
+RUN ./gradlew --no-daemon :data-sources-service:jar
 
 FROM eclipse-temurin:17-jre-jammy
 
-WORKDIR /app
-COPY --from=builder /app/data-sources-service/build/libs/app.jar /app/app.jar
+COPY --from=builder /app/data-sources-service/build/scripts/* /usr/bin/
+COPY --from=builder /app/data-sources-service/build/third-party/* /usr/lib/
+COPY --from=builder /app/data-sources-service/build/libs/*.jar /usr/lib/
+COPY --from=builder /app/data-sources-service/src/main/resources/config.yaml /etc/data-sources-service/config.yaml
+
+USER 101
 
 EXPOSE 8084
 
-ENTRYPOINT ["java", "-jar", "app.jar"] 
+ENTRYPOINT ["data-sources-service"]

--- a/data-sources-service/build.gradle.kts
+++ b/data-sources-service/build.gradle.kts
@@ -10,19 +10,3 @@ dependencies {
     implementation(project(":core"))
     testImplementation(libs.mockk)
 }
-
-tasks.jar {
-    manifest {
-        attributes(mapOf("Main-Class" to application.mainClass.get()))
-    }
-}
-
-tasks.shadowJar {
-    archiveBaseName.set("app")
-    archiveVersion.set("")
-    archiveClassifier.set("")
-    mergeServiceFiles()
-    manifest {
-        attributes(mapOf("Main-Class" to application.mainClass.get()))
-    }
-}

--- a/data-sources-service/src/main/kotlin/org/radarbase/datasources/DataSourcesApplication.kt
+++ b/data-sources-service/src/main/kotlin/org/radarbase/datasources/DataSourcesApplication.kt
@@ -24,7 +24,10 @@ class DataSourcesApplication {
         @JvmStatic
         fun main(args: Array<String>) {
             val config = try {
-                ConfigLoader.loadConfig<DataSourcesServiceConfig>("config.yaml", args)
+                ConfigLoader.loadConfig<DataSourcesServiceConfig>(
+                    listOf("data-sources-service/src/main/resources/config.yaml", "/etc/data-sources-service/config.yaml"),
+                    args,
+                )
             } catch (_: IllegalArgumentException) {
                 logger.error("No configuration file was found.")
                 logger.error("Usage: data-sources-service <config-file>")

--- a/delegate-api/Dockerfile
+++ b/delegate-api/Dockerfile
@@ -1,18 +1,33 @@
-ARG VERSION=1.0.0
-FROM eclipse-temurin:17-jdk-jammy as builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy AS builder
 
 WORKDIR /app
-COPY gradle/wrapper/gradle-wrapper.jar gradle/wrapper/
-COPY gradlew .
-RUN chmod +x /app/gradlew
-COPY . .
-RUN ./gradlew :delegate-api:shadowJar --no-daemon
+
+COPY gradle/ gradle/
+COPY gradlew build.gradle.kts settings.gradle.kts ./
+COPY core/build.gradle.kts core/
+COPY contract/build.gradle.kts contract/
+COPY delegate-api/build.gradle.kts delegate-api/
+
+RUN chmod +x gradlew && ./gradlew --no-daemon \
+    :delegate-api:downloadDependencies \
+    :delegate-api:copyDependencies \
+    :delegate-api:startScripts
+
+COPY core/src/ core/src/
+COPY contract/src/ contract/src/
+COPY delegate-api/src/ delegate-api/src/
+
+RUN ./gradlew --no-daemon :delegate-api:jar
 
 FROM eclipse-temurin:17-jre-jammy
 
-WORKDIR /app
-COPY --from=builder /app/delegate-api/build/libs/app.jar /app/app.jar
+COPY --from=builder /app/delegate-api/build/scripts/* /usr/bin/
+COPY --from=builder /app/delegate-api/build/third-party/* /usr/lib/
+COPY --from=builder /app/delegate-api/build/libs/*.jar /usr/lib/
+COPY --from=builder /app/delegate-api/src/main/resources/config.yaml /etc/delegate-api/config.yaml
+
+USER 101
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"] 
+ENTRYPOINT ["delegate-api"]

--- a/delegate-api/build.gradle.kts
+++ b/delegate-api/build.gradle.kts
@@ -11,19 +11,3 @@ dependencies {
     implementation(project(":core"))
     testImplementation(libs.mockk)
 }
-
-tasks.jar {
-    manifest {
-        attributes(mapOf("Main-Class" to application.mainClass.get()))
-    }
-}
-
-tasks.shadowJar {
-    archiveBaseName.set("app")
-    archiveVersion.set("")
-    archiveClassifier.set("")
-    mergeServiceFiles()
-    manifest {
-        attributes(mapOf("Main-Class" to application.mainClass.get()))
-    }
-}

--- a/delegate-api/src/main/kotlin/org/radarbase/delegate/DelegateApplication.kt
+++ b/delegate-api/src/main/kotlin/org/radarbase/delegate/DelegateApplication.kt
@@ -13,7 +13,10 @@ class DelegateApplication {
 
         @JvmStatic
         fun main(args: Array<String>) {
-            val config = ConfigLoader.loadConfig<DelegateConfig>("config.yaml", args)
+            val config = ConfigLoader.loadConfig<DelegateConfig>(
+                listOf("delegate-api/src/main/resources/config.yaml", "/etc/delegate-api/config.yaml"),
+                args,
+            )
 
             val resourceConfig: ResourceConfig = ConfigLoader.loadResources(config.resourceConfig, config)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,85 @@
+# This docker-compose is a work in progress.
+# The auth setup for the delegate API requires the Management Portal, Kratos,
+# and other supporting services, which will be added once local end-to-end
+# testing of the microservices with real Kratos and MP deployment is underway.
+
+networks:
+  public:
+    driver: bridge
+  backend:
+    driver: bridge
+    internal: true
+
+services:
+  #---------------------------------------------------------------------------#
+  # Delegate API (Gateway)                                                    #
+  #---------------------------------------------------------------------------#
+  delegate-api:
+    build:
+      context: .
+      dockerfile: delegate-api/Dockerfile
+    image: radarbase/radar-platform-delegate-api:SNAPSHOT
+    ports:
+      - "8080:8080"
+    networks:
+      - public
+      - backend
+    depends_on:
+      - user-service
+      - project-service
+      - config-service
+      - data-sources-service
+    volumes:
+      - ./docker/delegate-api.yaml:/etc/delegate-api/config.yaml
+
+  #---------------------------------------------------------------------------#
+  # User Service                                                              #
+  #---------------------------------------------------------------------------#
+  user-service:
+    build:
+      context: .
+      dockerfile: user-service/Dockerfile
+    image: radarbase/radar-platform-user-service:SNAPSHOT
+    networks:
+      - backend
+    volumes:
+      - ./docker/user-service.yaml:/etc/user-service/config.yaml
+
+  #---------------------------------------------------------------------------#
+  # Project Service                                                           #
+  #---------------------------------------------------------------------------#
+  project-service:
+    build:
+      context: .
+      dockerfile: project-service/Dockerfile
+    image: radarbase/radar-platform-project-service:SNAPSHOT
+    networks:
+      - backend
+    volumes:
+      - ./docker/project-service.yaml:/etc/project-service/config.yaml
+
+  #---------------------------------------------------------------------------#
+  # Config Service                                                            #
+  #---------------------------------------------------------------------------#
+  config-service:
+    build:
+      context: .
+      dockerfile: config-service/Dockerfile
+    image: radarbase/radar-platform-config-service:SNAPSHOT
+    networks:
+      - backend
+    volumes:
+      - ./docker/config-service.yaml:/etc/config-service/config.yaml
+
+  #---------------------------------------------------------------------------#
+  # Data Sources Service                                                      #
+  #---------------------------------------------------------------------------#
+  data-sources-service:
+    build:
+      context: .
+      dockerfile: data-sources-service/Dockerfile
+    image: radarbase/radar-platform-data-sources-service:SNAPSHOT
+    networks:
+      - backend
+    volumes:
+      - ./docker/data-sources-service.yaml:/etc/data-sources-service/config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@
 # The auth setup for the delegate API requires the Management Portal, Kratos,
 # and other supporting services, which will be added once local end-to-end
 # testing of the microservices with real Kratos and MP deployment is underway.
+# Also the docker compose setup is using volumes to mount config files,
+# this needs to be updated to environment variables, but that needs work on
+# config file first and using the radar jersey helper methods in code, then it will be updated in docker
 
 networks:
   public:

--- a/docker/config-service.yaml
+++ b/docker/config-service.yaml
@@ -1,0 +1,34 @@
+server:
+  baseUri: "http://0.0.0.0:8083"
+
+logging:
+  level: "INFO"
+  file: "logs/config-service.log"
+  pattern: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+
+providers:
+  github:
+    enabled: true
+    baseUrl: "https://raw.githubusercontent.com/RADAR-base/study-definitions/main"
+    owner: "RADAR-base"
+    repo: "study-definitions"
+    branch: "main"
+    token: ""
+    questionnaireRepoOwner: "RADAR-base"
+    questionnaireRepo: "RADAR-REDCap-aRMT-Definitions"
+    questionnaireRepoBranch: "master"
+    protocolRepoOwner: "RADAR-base"
+    protocolRepo: "RADAR-aRMT-protocols"
+    protocolRepoBranch: "master"
+    enrolmentRepoOwner: "RADAR-base"
+    enrolmentRepo: "radar-self-enrolment-definitions"
+    enrolmentRepoBranch: "main"
+  appConfig:
+    enabled: false
+    basePath: "/etc/RADAR-base/study-config"
+  db:
+    enabled: false
+    jdbcUrl: ""
+    username: ""
+    password: ""
+  order: [ "github", "appConfig", "db" ]

--- a/docker/data-sources-service.yaml
+++ b/docker/data-sources-service.yaml
@@ -1,0 +1,162 @@
+server:
+  baseUri: "http://0.0.0.0:8084"
+  isJmxEnabled: true
+
+logging:
+  level: "INFO"
+  file: "logs/data-sources-service.log"
+  pattern: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+
+serviceAuth:
+  clientId: platform_backend
+  clientSecret: secret
+  tokenEndpoint: http://hydra-public:4444/oauth2/token
+  audience: "res_ManagementPortal res_restAuthorizer"
+  scope: SOURCEDATA.CREATE SOURCETYPE.UPDATE SOURCETYPE.DELETE AUTHORITY.UPDATE MEASUREMENT.DELETE PROJECT.READ AUDIT.CREATE USER.DELETE AUTHORITY.DELETE SUBJECT.DELETE MEASUREMENT.UPDATE SOURCEDATA.UPDATE SUBJECT.READ USER.UPDATE SOURCETYPE.CREATE AUTHORITY.READ USER.CREATE SOURCE.CREATE SOURCE.READ SUBJECT.CREATE ROLE.UPDATE ROLE.READ MEASUREMENT.READ PROJECT.UPDATE PROJECT.DELETE ROLE.DELETE SOURCE.DELETE SOURCETYPE.READ ROLE.CREATE SOURCEDATA.DELETE SUBJECT.UPDATE SOURCE.UPDATE PROJECT.CREATE AUDIT.READ MEASUREMENT.CREATE AUDIT.DELETE AUDIT.UPDATE AUTHORITY.CREATE USER.READ SOURCEDATA.READ
+
+managementPortal:
+  baseUrl: "http://management-portal:8080/managementportal"
+  timeoutSeconds: 5
+  maxRetries: 3
+
+restSources:
+  baseUrl: "http://rest-sources-backend:8080/rest-sources/backend"
+  timeoutSeconds: 5
+  maxRetries: 3
+
+sources:
+  - id: passive-app
+    name: Passive App (pRMT)
+    category: mobile
+    integration: prmt
+    dataTypes:
+      - accelerometer
+      - battery_level
+      - gyroscope
+      - light_sensor
+      - magnetic_field
+      - step_count
+      - location_gps
+      - phone_calls
+      - sms_messages
+      - sms_unread_count
+      - phone_contacts
+      - bluetooth_devices
+      - bluetooth_device_scanning
+      - app_usage_events
+      - user_interactions
+
+  - id: active-app
+    name: Active App (aRMT)
+    category: mobile
+    integration: armt
+    dataTypes:
+      - questionnaire_responses
+      - speech_task
+
+  - id: healthkit
+    name: HealthKit
+    category: mobile
+    integration: armt
+    dataTypes:
+      - activity
+      - heart_rate
+      - sleep
+      - readiness_score
+
+  - id: oura-ring
+    name: Oura Ring
+    category: wearable
+    integration: rest-connector
+    dataTypes:
+      - activity
+      - heart_rate
+      - sleep
+      - stress_tracking
+      - readiness_score
+      - spo2
+      - temperature
+
+  - id: apple-watch
+    name: Apple Watch (and iPhones)
+    category: wearable
+    integration: armt
+    dataTypes:
+      - activity
+      - heart_rate
+      - sleep
+      - hrv
+      - spo2
+      - temperature
+
+  - id: garmin
+    name: Garmin Devices
+    category: wearable
+    integration: rest-connector
+    dataTypes:
+      - activity
+      - heart_rate
+      - sleep
+      - stress_tracking
+      - vo2_max
+      - body_battery
+      - spo2_night_time_and_on_demand
+      - respiration_rate
+
+  - id: fitbit
+    name: Fitbit Devices
+    category: wearable
+    integration: rest-connector
+    dataTypes:
+      - steps
+      - heart_rate_ppg
+      - hrv_ppg
+      - sleep
+      - temperature
+      - irregular_heart_rate
+
+  - id: polar-vantage-v3
+    name: Polar Vantage V3
+    category: wearable
+    integration: passive-app-prmt
+    dataTypes:
+      - raw_acceleration
+      - steps
+      - heart_rate_ppg
+      - pp_interval_ms
+      - wrist_ecg
+      - blood_volume_pulse_ppg
+      - sleep_stages
+      - temperature
+
+  - id: polar-h10
+    name: Polar H10 Heart Rate Sensor
+    category: sensor
+    integration: passive-app-prmt
+    dataTypes:
+      - raw_acceleration
+      - heart_rate_ppg
+      - rr_interval_ms
+
+  - id: empatica-e4
+    name: Empatica E4
+    category: wearable
+    integration: passive-app-prmt
+    dataTypes:
+      - raw_acceleration
+      - heart_rate_ppg
+      - blood_volume_pulse_ppg
+      - electrodermal_activity
+      - temperature
+
+  - id: iot-sensors
+    name: IoT Sensors
+    category: iot
+    integration: radar-iot
+    dataTypes:
+      - temperature
+      - humidity
+      - motion
+      - light
+      - air_quality
+      - gas_sensors

--- a/docker/delegate-api.yaml
+++ b/docker/delegate-api.yaml
@@ -1,0 +1,15 @@
+auth:
+  managementPortal:
+    url: http://management-portal:8080
+  resourceName: res_ManagementPortal
+  issuer: http://hydra-public:4444
+  publicKeyUrls: [
+    "http://hydra-public:4444/.well-known/jwks.json"
+  ]
+
+contract:
+  user: http://user-service:8081/user-service
+  participant: http://user-service:8081/user-service
+  project: http://project-service:8082/project-service
+  config: http://config-service:8083/config-service
+  dataSources: http://data-sources-service:8084/data-sources-service

--- a/docker/project-service.yaml
+++ b/docker/project-service.yaml
@@ -1,0 +1,29 @@
+serviceAuth:
+  clientId: platform_backend
+  clientSecret: secret
+  tokenEndpoint: http://hydra-public:4444/oauth2/token
+  scope: SOURCEDATA.CREATE SOURCETYPE.UPDATE SOURCETYPE.DELETE AUTHORITY.UPDATE MEASUREMENT.DELETE PROJECT.READ AUDIT.CREATE USER.DELETE AUTHORITY.DELETE SUBJECT.DELETE MEASUREMENT.UPDATE SOURCEDATA.UPDATE SUBJECT.READ USER.UPDATE SOURCETYPE.CREATE AUTHORITY.READ USER.CREATE SOURCE.CREATE SOURCE.READ SUBJECT.CREATE ROLE.UPDATE ROLE.READ MEASUREMENT.READ PROJECT.UPDATE PROJECT.DELETE ROLE.DELETE SOURCE.DELETE SOURCETYPE.READ ROLE.CREATE SOURCEDATA.DELETE SUBJECT.UPDATE SOURCE.UPDATE PROJECT.CREATE AUDIT.READ MEASUREMENT.CREATE AUDIT.DELETE AUDIT.UPDATE AUTHORITY.CREATE USER.READ SOURCEDATA.READ
+  audience: res_ManagementPortal
+
+radar:
+  baseUrl: "http://management-portal:8080/managementportal/api"
+  timeout: 30000
+  maxRetries: 3
+  auth:
+    enabled: true
+    tokenHeader: "Authorization"
+    tokenPrefix: "Bearer"
+
+server:
+  port: 8082
+  host: "0.0.0.0"
+  cors:
+    enabled: true
+    allowedOrigins: [ "*" ]
+    allowedMethods: [ "GET", "POST", "PUT", "DELETE", "OPTIONS" ]
+    allowedHeaders: [ "Authorization", "Content-Type" ]
+
+logging:
+  level: "INFO"
+  file: "logs/project-service.log"
+  format: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"

--- a/docker/user-service.yaml
+++ b/docker/user-service.yaml
@@ -1,0 +1,26 @@
+server:
+  baseUri: "http://0.0.0.0:8081"
+
+serviceAuth:
+  clientId: platform_backend
+  clientSecret: secret
+  tokenEndpoint: http://hydra-public:4444/oauth2/token
+  scope: SOURCEDATA.CREATE SOURCETYPE.UPDATE SOURCETYPE.DELETE AUTHORITY.UPDATE MEASUREMENT.DELETE PROJECT.READ AUDIT.CREATE USER.DELETE AUTHORITY.DELETE SUBJECT.DELETE MEASUREMENT.UPDATE SOURCEDATA.UPDATE SUBJECT.READ USER.UPDATE SOURCETYPE.CREATE AUTHORITY.READ USER.CREATE SOURCE.CREATE SOURCE.READ SUBJECT.CREATE ROLE.UPDATE ROLE.READ MEASUREMENT.READ PROJECT.UPDATE PROJECT.DELETE ROLE.DELETE SOURCE.DELETE SOURCETYPE.READ ROLE.CREATE SOURCEDATA.DELETE SUBJECT.UPDATE SOURCE.UPDATE PROJECT.CREATE AUDIT.READ MEASUREMENT.CREATE AUDIT.DELETE AUDIT.UPDATE AUTHORITY.CREATE USER.READ SOURCEDATA.READ
+
+kratos:
+  baseUrl: "http://kratos:4434"
+  timeoutSeconds: 5
+  maxRetries: 3
+  endpoints:
+    identities: "/admin/kratos/identities"
+    identity: "/admin/kratos/identities/{id}"
+
+managementPortal:
+  baseUrl: "http://management-portal:8080/managementportal"
+  timeoutSeconds: 5
+  maxRetries: 3
+
+logging:
+  level: "INFO"
+  file: "logs/user-service.log"
+  pattern: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,4 +60,3 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 radar-kotlin = { id = "org.radarbase.radar-kotlin", version.ref = "radar-commons-gradle" }
 radar-dependency-management = { id = "org.radarbase.radar-dependency-management", version.ref = "radar-commons-gradle" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }

--- a/project-service/Dockerfile
+++ b/project-service/Dockerfile
@@ -1,19 +1,31 @@
-ARG VERSION=1.0.0
-FROM eclipse-temurin:17-jdk-jammy as builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy AS builder
 
 WORKDIR /app
-COPY gradle/wrapper/gradle-wrapper.jar gradle/wrapper/
-COPY gradlew .
-RUN chmod +x /app/gradlew
-COPY . .
-RUN ./gradlew :project-service:shadowJar --no-daemon
+
+COPY gradle/ gradle/
+COPY gradlew build.gradle.kts settings.gradle.kts ./
+COPY core/build.gradle.kts core/
+COPY project-service/build.gradle.kts project-service/
+
+RUN chmod +x gradlew && ./gradlew --no-daemon \
+    :project-service:downloadDependencies \
+    :project-service:copyDependencies \
+    :project-service:startScripts
+
+COPY core/src/ core/src/
+COPY project-service/src/ project-service/src/
+
+RUN ./gradlew --no-daemon :project-service:jar
 
 FROM eclipse-temurin:17-jre-jammy
 
-WORKDIR /app
-COPY --from=builder /app/project-service/build/libs/app.jar /app/app.jar
+COPY --from=builder /app/project-service/build/scripts/* /usr/bin/
+COPY --from=builder /app/project-service/build/third-party/* /usr/lib/
+COPY --from=builder /app/project-service/build/libs/*.jar /usr/lib/
+COPY --from=builder /app/project-service/src/main/resources/config.yaml /etc/project-service/config.yaml
+
+USER 101
 
 EXPOSE 8082
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
-
+ENTRYPOINT ["project-service"]

--- a/project-service/build.gradle.kts
+++ b/project-service/build.gradle.kts
@@ -9,19 +9,3 @@ application {
 dependencies {
     implementation(project(":core"))
 }
-
-tasks.jar {
-    manifest {
-        attributes(mapOf("Main-Class" to application.mainClass.get()))
-    }
-}
-
-tasks.shadowJar {
-    archiveBaseName.set("app")
-    archiveVersion.set("")
-    archiveClassifier.set("")
-    mergeServiceFiles()
-    manifest {
-        attributes(mapOf("Main-Class" to application.mainClass.get()))
-    }
-}

--- a/project-service/src/main/kotlin/org/radarbase/project/ProjectServiceApplication.kt
+++ b/project-service/src/main/kotlin/org/radarbase/project/ProjectServiceApplication.kt
@@ -16,7 +16,10 @@ class ProjectServiceApplication {
         @JvmStatic
         fun main(args: Array<String>) {
             val config = try {
-                ConfigLoader.loadConfig<ProjectServiceConfiguration>("config.yaml", args)
+                ConfigLoader.loadConfig<ProjectServiceConfiguration>(
+                    listOf("project-service/src/main/resources/config.yaml", "/etc/project-service/config.yaml"),
+                    args,
+                )
             } catch (_: IllegalArgumentException) {
                 logger.error("No configuration file was found.")
                 logger.error("Usage: project-service <config-file>")

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,18 +1,31 @@
-ARG VERSION=1.0.0
-FROM eclipse-temurin:17-jdk-jammy as builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy AS builder
 
 WORKDIR /app
-COPY gradle/wrapper/gradle-wrapper.jar gradle/wrapper/
-COPY gradlew .
-RUN chmod +x /app/gradlew
-COPY . .
-RUN ./gradlew :user-service:shadowJar --no-daemon
+
+COPY gradle/ gradle/
+COPY gradlew build.gradle.kts settings.gradle.kts ./
+COPY core/build.gradle.kts core/
+COPY user-service/build.gradle.kts user-service/
+
+RUN chmod +x gradlew && ./gradlew --no-daemon \
+    :user-service:downloadDependencies \
+    :user-service:copyDependencies \
+    :user-service:startScripts
+
+COPY core/src/ core/src/
+COPY user-service/src/ user-service/src/
+
+RUN ./gradlew --no-daemon :user-service:jar
 
 FROM eclipse-temurin:17-jre-jammy
 
-WORKDIR /app
-COPY --from=builder /app/user-service/build/libs/app.jar /app/app.jar
+COPY --from=builder /app/user-service/build/scripts/* /usr/bin/
+COPY --from=builder /app/user-service/build/third-party/* /usr/lib/
+COPY --from=builder /app/user-service/build/libs/*.jar /usr/lib/
+COPY --from=builder /app/user-service/src/main/resources/config.yaml /etc/user-service/config.yaml
+
+USER 101
 
 EXPOSE 8081
 
-ENTRYPOINT ["java", "-jar", "app.jar"] 
+ENTRYPOINT ["user-service"]

--- a/user-service/build.gradle.kts
+++ b/user-service/build.gradle.kts
@@ -13,19 +13,3 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.ktor.client.mock)
 }
-
-tasks.jar {
-    manifest {
-        attributes(mapOf("Main-Class" to application.mainClass.get()))
-    }
-}
-
-tasks.shadowJar {
-    archiveBaseName.set("app")
-    archiveVersion.set("")
-    archiveClassifier.set("")
-    mergeServiceFiles()
-    manifest {
-        attributes(mapOf("Main-Class" to application.mainClass.get()))
-    }
-}

--- a/user-service/src/main/kotlin/org/radarbase/user/UserApplication.kt
+++ b/user-service/src/main/kotlin/org/radarbase/user/UserApplication.kt
@@ -17,7 +17,10 @@ class UserApplication {
         fun main(args: Array<String>) {
             val config =
                 try {
-                    ConfigLoader.loadConfig<UserServiceConfig>("config.yaml", args)
+                    ConfigLoader.loadConfig<UserServiceConfig>(
+                        listOf("user-service/src/main/resources/config.yaml", "/etc/user-service/config.yaml"),
+                        args,
+                    )
                 } catch (_: IllegalArgumentException) {
                     logger.error("No configuration file was found.")
                     logger.error("Usage: user-service <config-file>")


### PR DESCRIPTION
 Removed shadow plugin and all `shadowJar/jar` task configurations from service build scripts, switching to gradle's `application` plugin and using the `startScripts` task for launching services. Also added multi-platform support to Dockerfiles and improved layer caching in the Docker setup.
                                                                                                                                                                     
Created `docker-compose.yml` (WIP). Currently using per-service config files mounted as volumes, but in the future this can be replaced by environment variables, but this requires changes first in the config code to utilize the radar-jersey functionality for registering env vars.
